### PR TITLE
Refactor Dto4j and related classes to support profile-based serialization

### DIFF
--- a/src/main/java/com/slxca/Dto4j.java
+++ b/src/main/java/com/slxca/Dto4j.java
@@ -22,8 +22,17 @@ public class Dto4j {
             .registerModule(new JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
+
+    Dto4j(String profile) {
+        this.profile = Objects.requireNonNullElse(profile, DEFAULT_PROFILE);
+    }
+
+    public static Dto4j builder(String profile) {
+        return new Dto4j(profile);
+    }
+
     public static Dto4j builder() {
-        return new Dto4j();
+        return new Dto4j(null);
     }
 
     public Dto4j profile(String profile) {
@@ -95,7 +104,8 @@ public class Dto4j {
 
             if(annotation == null) continue;
             if(annotation.ignore()) continue;
-            if(!Arrays.asList(annotation.profile()).contains(profile)) continue;
+
+            if(!Arrays.asList(annotation.value()).contains(profile) && !Arrays.asList(annotation.profile()).contains(profile)) continue;
 
             field.setAccessible(true);
 
@@ -108,7 +118,8 @@ public class Dto4j {
                 }
 
                 else if (isDtoObject(value)) {
-                    value = Dto4j.builder().profile(profile).object(value).toMap();
+                    if (annotation.profile() == null || annotation.profile().length == 0) value = Dto4j.builder().object(value).toMap();
+                    else value = Dto4j.builder().profile(profile).object(value).toMap();
                 }
 
                 else if (value instanceof Iterable<?>) {

--- a/src/main/java/com/slxca/dto/DtoProperty.java
+++ b/src/main/java/com/slxca/dto/DtoProperty.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Target;
 public @interface DtoProperty {
     String name() default "";
     boolean ignore() default false;
+    String[] value() default {"_default"};
     String[] profile() default {"_default"};
     Class<? extends DtoConverter<?, ?>> converter() default NoConverter.class;
 }

--- a/src/test/java/donut/DonutObject.java
+++ b/src/test/java/donut/DonutObject.java
@@ -6,10 +6,10 @@ import com.slxca.dto.DtoProperty;
 @Dto
 public class DonutObject {
 
-    @DtoProperty
+    @DtoProperty(profile = "GET_DONUT")
     public String name = "Glazed";
 
-    @DtoProperty(name = "donutType")
+    @DtoProperty(value = "GET_DONUT", name = "donutType")
     public DonutEnum type = DonutEnum.CHOCOLATE;
 
 }

--- a/src/test/java/donut/DonutTest.java
+++ b/src/test/java/donut/DonutTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DonutTest {
 
     Dto4j dto = Dto4j.builder()
+            .profile("GET_DONUT")
             .object(new DonutObject());
 
     @Test


### PR DESCRIPTION
### Refactor Dto4j to Support Profile-Based Serialization

#### Summary

This PR refactors the `Dto4j` utility and related annotations to introduce **profile-based serialization**. It allows fine-grained control over which fields are serialized based on active profiles.

#### Key Changes

* Added `profile` attribute to `@DtoProperty` annotation (in addition to the existing `value` field).
* Modified serialization logic in `Dto4j` to respect the `profile` attribute.
* Enhanced builder pattern to support setting the profile explicitly.
* Updated test model (`DonutObject`) and test case (`DonutTest`) to reflect and validate the new functionality.

#### Why?

This makes the serialization mechanism more flexible and context-aware, supporting use cases like:

* Different API views (e.g., `GET_DONUT`, `CREATE_DONUT`)
* Data minimization for specific consumers
* Profile-based DTO transformation logic

#### Impact

Backward compatible with existing usages where no profile is specified (defaults to `"_default"`). No breaking changes expected.
