### PR TITLE
Remove profile specification from DonutObject properties

### DIFF
--- a/src/test/java/donut/DonutObject.java
+++ b/src/test/java/donut/DonutObject.java
@@ -6,10 +6,9 @@ import com.slxca.dto.DtoProperty;
 @Dto
 public class DonutObject {
 
-    @DtoProperty(profile = "GET_DONUT")
+    @DtoProperty
     public String name = "Glazed";
 
-    @DtoProperty(value = "GET_DONUT", name = "donutType")
+    @DtoProperty(name = "donutType")
     public DonutEnum type = DonutEnum.CHOCOLATE;
-
 }

--- a/src/test/java/donut/DonutTest.java
+++ b/src/test/java/donut/DonutTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DonutTest {
 
     Dto4j dto = Dto4j.builder()
-            .profile("GET_DONUT")
             .object(new DonutObject());
 
     @Test


### PR DESCRIPTION
This pull request removes the use of the `profile` attribute in the `@DtoProperty` annotations and the `Dto4j` builder configuration for the "GET_DONUT" profile. These changes simplify the code by eliminating unnecessary configuration.

Annotation changes:

* [`src/test/java/donut/DonutObject.java`](diffhunk://#diff-ccca0be29464aab3c59bc81a7787a8d838e45453bf09d201bfe3cc8e4155cf88L9-L14): Removed the `profile` attribute from the `@DtoProperty` annotations on the `name` and `type` fields.

Configuration changes:

* [`src/test/java/donut/DonutTest.java`](diffhunk://#diff-c43b0541f84ededf602cd01f437746d81d9a9c7ae82aed6f2dc2f723a279c08fL14): Removed the `.profile("GET_DONUT")` configuration from the `Dto4j` builder.