### PR TITLE
Sort JSON output by type priority

### DIFF
--- a/src/main/java/com/slxca/Dto4j.java
+++ b/src/main/java/com/slxca/Dto4j.java
@@ -65,7 +65,13 @@ public class Dto4j {
 
     public String toJson() {
         try {
-            return objectMapper.writeValueAsString(data);
+            Map<String, Object> sortedData = new LinkedHashMap<>();
+
+            data.entrySet().stream()
+                    .sorted(Comparator.comparingInt(e -> typePriority(e.getValue())))
+                    .forEachOrdered(e -> sortedData.put(e.getKey(), e.getValue()));
+
+            return objectMapper.writeValueAsString(sortedData);
         } catch (Exception e) {
             throw new RuntimeException("Failed to convert to JSON", e);
         }
@@ -163,5 +169,13 @@ public class Dto4j {
         }
 
         return false;
+    }
+
+
+    private int typePriority(Object value) {
+        if (value instanceof String || value instanceof Boolean || value instanceof Map) return 0;
+        if (value instanceof Number) return 1;
+        if (value instanceof Collection || value instanceof Object[]) return 2;
+        return 3;
     }
 }


### PR DESCRIPTION
This pull request introduces changes to improve the JSON serialization behavior in the `Dto4j` class by sorting data based on type priority. A new helper method was added to define type priorities, ensuring consistent ordering of serialized data.

Enhancements to JSON serialization:

* [`src/main/java/com/slxca/Dto4j.java`](diffhunk://#diff-faaf9ca39c2710c6aadd85f7b22041ad59c677e6bf3a84fe8276b5ed28ed6c42L68-R74): Modified the `toJson` method to sort the `data` map by type priority before serialization. This ensures that the JSON output is consistently ordered based on the type of values.
* [`src/main/java/com/slxca/Dto4j.java`](diffhunk://#diff-faaf9ca39c2710c6aadd85f7b22041ad59c677e6bf3a84fe8276b5ed28ed6c42R173-R180): Added a new `typePriority` helper method to define priority levels for different data types, such as `String`, `Number`, and `Collection`. This method is used in the sorting logic of the `toJson` method.

Before:
```json
{
    "phoneNumber": "+1 123 4567890",
    "reports": 0,
    "name": "John Doe",
    "roles": [
        "USER"
    ],
    "id": 1,
    "private": true,
    "likes": 0
}
```

After:
```json
{
    "phoneNumber": "+1 123 4567890",
    "name": "John Doe",
    "private": true,
    "id": 1,
    "reports": 0,
    "likes": 0,
    "roles": [
        "USER"
    ]
}
```
